### PR TITLE
Remove deprecated coverage scripts from qem_env/bin

### DIFF
--- a/qem_env/bin/coverage
+++ b/qem_env/bin/coverage
@@ -1,7 +1,0 @@
-#!/root/repo/qem_env/bin/python3
-import sys
-from coverage.cmdline import main
-if __name__ == '__main__':
-    if sys.argv[0].endswith('.exe'):
-        sys.argv[0] = sys.argv[0][:-4]
-    sys.exit(main())

--- a/qem_env/bin/coverage-3.12
+++ b/qem_env/bin/coverage-3.12
@@ -1,7 +1,0 @@
-#!/root/repo/qem_env/bin/python3
-import sys
-from coverage.cmdline import main
-if __name__ == '__main__':
-    if sys.argv[0].endswith('.exe'):
-        sys.argv[0] = sys.argv[0][:-4]
-    sys.exit(main())

--- a/qem_env/bin/coverage3
+++ b/qem_env/bin/coverage3
@@ -1,7 +1,0 @@
-#!/root/repo/qem_env/bin/python3
-import sys
-from coverage.cmdline import main
-if __name__ == '__main__':
-    if sys.argv[0].endswith('.exe'):
-        sys.argv[0] = sys.argv[0][:-4]
-    sys.exit(main())


### PR DESCRIPTION
## Summary
- Removed three deprecated coverage scripts (`coverage`, `coverage-3.12`, `coverage3`) from the `qem_env/bin` directory
- These scripts were redundant and no longer needed for the project

## Changes
- Deleted `qem_env/bin/coverage` script
- Deleted `qem_env/bin/coverage-3.12` script
- Deleted `qem_env/bin/coverage3` script

## Test plan
- Verified that the removal of these scripts does not affect the existing test coverage functionality
- Ensured no references to these scripts remain in the codebase or build processes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5a22905a-d702-4cb6-b709-a4f0a4607ed9

## Summary by Sourcery

Chores:
- Remove coverage, coverage-3.12, and coverage3 scripts from qem_env/bin